### PR TITLE
Add common-protection-api support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	modImplementation include("me.lucko:fabric-permissions-api:0.1-SNAPSHOT")
 	modImplementation include("eu.pb4:sgui:1.1.4+1.19.1")
 	modImplementation include("eu.pb4:player-data-api:0.2.1+1.19")
+	modImplementation include("eu.pb4:common-protection-api:1.0.0")
 	//modImplementation include("eu.pb4:sidebar-api:0.1.1+1.19")
 
 	modImplementation include("fr.catcore:server-translations-api:1.4.16+1.19")

--- a/src/main/java/eu/pb4/armorstandeditor/ArmorStandEditorMod.java
+++ b/src/main/java/eu/pb4/armorstandeditor/ArmorStandEditorMod.java
@@ -8,6 +8,7 @@ import eu.pb4.armorstandeditor.util.GeneralCommands;
 import eu.pb4.armorstandeditor.legacy.LegacyEvents;
 import eu.pb4.armorstandeditor.legacy.LegacyPlayerExt;
 import eu.pb4.armorstandeditor.util.TextUtils;
+import eu.pb4.common.protection.api.CommonProtection;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -52,7 +53,9 @@ public class ArmorStandEditorMod implements ModInitializer {
             if (player instanceof ServerPlayerEntity
                     && EditorActions.OPEN_EDITOR.canUse(player)
                     && itemStack.getItem() == config.armorStandTool
-                    && (!config.configData.requireIsArmorStandEditorTag || itemStack.getOrCreateNbt().getBoolean("isArmorStandEditor"))) {
+                    && (!config.configData.requireIsArmorStandEditorTag || itemStack.getOrCreateNbt().getBoolean("isArmorStandEditor"))
+                    && CommonProtection.canInteractEntity(world, entity, player.getGameProfile(), player)
+            ) {
 
 
                 if (checkDisguise) {

--- a/src/main/java/eu/pb4/armorstandeditor/ArmorStandEditorMod.java
+++ b/src/main/java/eu/pb4/armorstandeditor/ArmorStandEditorMod.java
@@ -56,9 +56,8 @@ public class ArmorStandEditorMod implements ModInitializer {
 
 
                 if (checkDisguise) {
-                    if (entity instanceof EntityDisguise disguise && disguise.isDisguised() && disguise.getDisguiseType() == EntityType.ARMOR_STAND) {
+                    if (entity instanceof EntityDisguise disguise && disguise.isDisguised()) {
                         entity = disguise.getDisguiseEntity();
-                        return ActionResult.SUCCESS;
                     }
                 }
 

--- a/src/main/java/eu/pb4/armorstandeditor/gui/MoveGui.java
+++ b/src/main/java/eu/pb4/armorstandeditor/gui/MoveGui.java
@@ -1,6 +1,7 @@
 package eu.pb4.armorstandeditor.gui;
 
 import eu.pb4.armorstandeditor.util.TextUtils;
+import eu.pb4.common.protection.api.CommonProtection;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.s2c.play.UpdateSelectedSlotS2CPacket;
 import net.minecraft.sound.SoundEvents;
@@ -174,6 +175,9 @@ public class MoveGui extends BaseGui {
                     pos.y + this.playerLookingDirection.getOffsetY() * v,
                     pos.z + this.playerLookingDirection.getOffsetZ() * v
             );
+        }
+        if (!CommonProtection.canInteractEntity(this.context.player.getEntityWorld(), this.context.armorStand, this.context.player.getGameProfile(), this.context.player)) {
+            this.context.armorStand.setPosition(pos);
         }
     }
 

--- a/src/main/java/eu/pb4/armorstandeditor/legacy/LegacyEvents.java
+++ b/src/main/java/eu/pb4/armorstandeditor/legacy/LegacyEvents.java
@@ -5,6 +5,7 @@ import eu.pb4.armorstandeditor.config.Config;
 import eu.pb4.armorstandeditor.config.ConfigManager;
 import eu.pb4.armorstandeditor.mixin.ArmorStandEntityAccessor;
 import eu.pb4.armorstandeditor.util.ArmorStandData;
+import eu.pb4.common.protection.api.CommonProtection;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
 import net.fabricmc.fabric.api.event.player.UseEntityCallback;
@@ -201,6 +202,9 @@ public class LegacyEvents {
         switch (spei.aselegacy$getArmorStandEditorAction()) {
             case MOVE:
                 armorStand.teleport(posX + dX * power * val, posY + dY * power * val, posZ + dZ * power * val);
+                if (!CommonProtection.canInteractEntity(player.getWorld(), armorStand, player.getGameProfile(), player)) {
+                    armorStand.teleport(posX, posY, posZ);
+                }
                 break;
             case ROTATE:
                 armorStand.setYaw(armorStand.getYaw() + angleChange);


### PR DESCRIPTION
- Prevents players from editing armorstands, if they aren't allowed to interact with it.
- Prevents move actions if they result in the armorstand no longer being interactable.
- Fixes (?) a bug in the compatibility with disguiselib, I haven't tested my changes, but the previous code seems wrong.