### PR TITLE
Fixed: property permissions not working.

### DIFF
--- a/src/main/java/eu/pb4/armorstandeditor/gui/PropertyGui.java
+++ b/src/main/java/eu/pb4/armorstandeditor/gui/PropertyGui.java
@@ -32,7 +32,7 @@ public class PropertyGui extends BaseGui {
     @Override
     protected void buildUi() {
         for (var entry : ENTRIES) {
-            this.addSlot(entry(entry));
+            this.addSlot(entry.action, entry(entry));
         }
     }
 


### PR DESCRIPTION
Fixes an issue where the permissions for toggling specific armor stand properties are ignored.

This affects `toggle_size`, `toggle_arms`, `toggle_visibility`, `toggle_no_gravity` and `toggle_base`