### PR TITLE
Fixed the dupe that occurred when unloading an item frame while its inventory GUI was opened

### DIFF
--- a/src/main/java/eu/pb4/armorstandeditor/legacy/LegacyEditorGuis.java
+++ b/src/main/java/eu/pb4/armorstandeditor/legacy/LegacyEditorGuis.java
@@ -398,7 +398,15 @@ public class LegacyEditorGuis {
     public static void openItemFrameEditor(ServerPlayerEntity player, ItemFrameEntity entity) {
         ItemFrameEntityAccessor ifa = (ItemFrameEntityAccessor) entity;
 
-        SimpleGui gui = new SimpleGui(ScreenHandlerType.GENERIC_9X1, player, false);
+        SimpleGui gui = new SimpleGui(ScreenHandlerType.GENERIC_9X1, player, false){
+            @Override
+            public void onTick() {
+                if (entity.isRemoved() || entity.getPos().squaredDistanceTo(player.getPos()) > 24 * 24) {
+                    this.close();
+                }
+                super.onTick();
+            }
+        };
 
         ItemFrameInventory inventory = new ItemFrameInventory(entity);
 


### PR DESCRIPTION
The same dupe as: https://github.com/Patbox/ArmorStandEditor/pull/13 

This time with an item frame